### PR TITLE
ssl template change + first run of letsencrypt at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get install --no-install-recommends -y git cron vim
 RUN systemctl enable cron
 RUN cd / && git clone https://github.com/letsencrypt/letsencrypt
 RUN /letsencrypt/letsencrypt-auto certonly || exit 0
+RUN rm -rf /etc/letsencrypt/accounts/
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM jwilder/nginx-proxy:0.2.0
 
-RUN apt-get update && apt-get install --no-install-recommends -y git cron vim \
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get -fy -o Dpkg::Options::="--force-confnew" --force-yes -fuy dist-upgrade
+RUN apt-get install --no-install-recommends -y git cron vim \
  python python-dev virtualenv python-virtualenv gcc dialog libaugeas0 augeas-lenses \ 
  libssl-dev libffi-dev ca-certificates \
  && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
@@ -8,7 +11,7 @@ RUN systemctl enable cron
 RUN cd / && git clone https://github.com/letsencrypt/letsencrypt
 
 
-ENV DOCKER_GEN_VERSION 0.5.0
+ENV DOCKER_GEN_VERSION 0.7.0
 
 RUN wget https://github.com/jwilder/docker-gen/releases/download/$DOCKER_GEN_VERSION/docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \
  && tar -C /usr/local/bin -xvzf docker-gen-linux-amd64-$DOCKER_GEN_VERSION.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,11 @@ FROM jwilder/nginx-proxy:0.2.0
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get -fy -o Dpkg::Options::="--force-confnew" --force-yes -fuy dist-upgrade
-RUN apt-get install --no-install-recommends -y git cron vim \
- python python-dev virtualenv python-virtualenv gcc dialog libaugeas0 augeas-lenses \ 
- libssl-dev libffi-dev ca-certificates \
- && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get install --no-install-recommends -y git cron vim 
 RUN systemctl enable cron
 RUN cd / && git clone https://github.com/letsencrypt/letsencrypt
+RUN /letsencrypt/letsencrypt-auto certonly || exit 0
+RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
 ENV DOCKER_GEN_VERSION 0.7.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM jwilder/nginx-proxy:0.2.0
 
-RUN apt-get update && apt-get install --no-install-recommends -y git cron vim && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+RUN apt-get update && apt-get install --no-install-recommends -y git cron vim \
+ python python-dev virtualenv python-virtualenv gcc dialog libaugeas0 augeas-lenses \ 
+ libssl-dev libffi-dev ca-certificates \
+ && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 RUN systemctl enable cron
 RUN cd / && git clone https://github.com/letsencrypt/letsencrypt
 

--- a/Procfile
+++ b/Procfile
@@ -1,4 +1,4 @@
 nginx: nginx
 confgen: docker-gen -notify-output -watch -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
-sslgen: docker-gen -notify-output -watch -only-exposed -notify "/createSSL.sh" /app/ssl.tmpl /createSSL.sh
+sslgen: docker-gen -notify-output -watch -only-exposed -wait "500ms:2s" -notify "/createSSL.sh" /app/ssl.tmpl /createSSL.sh
 cron: /usr/sbin/cron -f 

--- a/ssl.tmpl
+++ b/ssl.tmpl
@@ -6,19 +6,20 @@ mkdir -p /var/www/letsencrypt
 {{ $optOutContainers := whereLabelDoesNotExist $ "letsencrypt.nocert" }}
 {{ $sslContainers := when $optIn $optInContainers $optOutContainers }} 
 
-{{ $containersForGeneration := groupByMulti $sslContainers "Env.VIRTUAL_HOST" "," }}
+{{ range $host, $containers := groupByMulti $sslContainers "Env.VIRTUAL_HOST" ","  }}
+  {{ range $container := $containers }}
+#### begin {{ $host }}  ####
+    {{ if contains $container.Env "LETSENCRYPT_EMAIL" }}
+      /letsencrypt/letsencrypt-auto certonly --email {{ $container.Env.LETSENCRYPT_EMAIL }} --agree-tos --keep-until-expiring --webroot -w /var/www/letsencrypt -d {{ $host }}
+    {{ else }}
+      /letsencrypt/letsencrypt-auto certonly --email info@{{ $host }} --agree-tos --keep-until-expiring --webroot -w /var/www/letsencrypt -d {{ $host }}
+    {{ end }}
+      
+    ln -sf /etc/letsencrypt/live/{{ $host }}/fullchain.pem /etc/nginx/certs/{{ $host }}.crt
+    ln -sf /etc/letsencrypt/live/{{ $host }}/privkey.pem /etc/nginx/certs/{{ $host }}.key
+#### end {{ $host }}  ####
 
-{{ range $containers := $containersForGeneration }}
-	{{ range $container := $containers }}
-		{{ if contains $container.Env "LETSENCRYPT_EMAIL" }}
-			/letsencrypt/letsencrypt-auto certonly --email {{ $container.Env.LETSENCRYPT_EMAIL }} --agree-tos --keep-until-expiring --webroot -w /var/www/letsencrypt -d {{ $container.Env.VIRTUAL_HOST }}
-		{{ else }}
-			/letsencrypt/letsencrypt-auto certonly --email info@{{ $container.Env.VIRTUAL_HOST }} --agree-tos --keep-until-expiring --webroot -w /var/www/letsencrypt -d {{ $container.Env.VIRTUAL_HOST }}
-		{{ end }}
-			
-		ln -sf /etc/letsencrypt/live/{{ $container.Env.VIRTUAL_HOST }}/fullchain.pem /etc/nginx/certs/{{ $container.Env.VIRTUAL_HOST }}.crt
-		ln -sf /etc/letsencrypt/live/{{ $container.Env.VIRTUAL_HOST }}/privkey.pem /etc/nginx/certs/{{ $container.Env.VIRTUAL_HOST }}.key
-
-		{{ end }}
-	{{ end }}
+  {{ end }}
+{{ end }}
 docker-gen -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
+


### PR DESCRIPTION
Hi,

I've modified the ssl template to be able to generate multiple certs for a container when VIRTUAL_HOST variable contains many urls separated by commas. 
It has been tested on a sandbox, and doesn't seem to break anything ;) 

I've added too a first run of letsencrypt-auto at build time, so it can download and install all python packages, and create its virtualenv, speeding up start of container.

let me know if theses modification can be merged.

Cheers
