### PR TITLE
updated nginx-proxy and cleared out conflicting log file(s)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy:0.4.0
+FROM jwilder/nginx-proxy:0.5.0
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV YES_FLAG=-y
@@ -14,6 +14,7 @@ RUN /certbot/certbot-auto certonly || exit 0
 #RUN cd / && git clone https://github.com/letsencrypt/letsencrypt
 #RUN /letsencrypt/letsencrypt-auto certonly || exit 0
 RUN rm -rf /etc/letsencrypt/accounts/
+RUN rm -rf /var/log/letsencrypt/*
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 

--- a/ssl.tmpl
+++ b/ssl.tmpl
@@ -4,17 +4,17 @@ mkdir -p /var/www/letsencrypt
 {{ $optIn := contains $.Env "LETSENCRYPT_OPT_IN" }}
 {{ $optInContainers := whereLabelExists $ "letsencrypt.cert" }}
 {{ $optOutContainers := whereLabelDoesNotExist $ "letsencrypt.nocert" }}
-{{ $sslContainers := when $optIn $optInContainers $optOutContainers }} 
+{{ $sslContainers := when $optIn $optInContainers $optOutContainers }}
 
 {{ range $host, $containers := groupByMulti $sslContainers "Env.VIRTUAL_HOST" ","  }}
   {{ range $container := $containers }}
 #### begin {{ $host }}  ####
     {{ if contains $container.Env "LETSENCRYPT_EMAIL" }}
-      /certbot/certbot-auto certonly -n -t --email {{ $container.Env.LETSENCRYPT_EMAIL }} --agree-tos --keep-until-expiring --webroot -w /var/www/letsencrypt -d {{ $host }}
+      /certbot/certbot-auto certonly -n -t --email {{ $container.Env.LETSENCRYPT_EMAIL }} --agree-tos --keep-until-expiring --no-self-upgrade --webroot -w /var/www/letsencrypt -d {{ $host }}
     {{ else }}
-      /certbot/certbot-auto certonly -n -t --email info@{{ $host }} --agree-tos --keep-until-expiring --webroot -w /var/www/letsencrypt -d {{ $host }}
+      /certbot/certbot-auto certonly -n -t --email info@{{ $host }} --agree-tos --keep-until-expiring --no-self-upgrade --webroot -w /var/www/letsencrypt -d {{ $host }}
     {{ end }}
-      
+
     ln -sf /etc/letsencrypt/live/{{ $host }}/fullchain.pem /etc/nginx/certs/{{ $host }}.crt
     ln -sf /etc/letsencrypt/live/{{ $host }}/privkey.pem /etc/nginx/certs/{{ $host }}.key
 #### end {{ $host }}  ####
@@ -22,4 +22,3 @@ mkdir -p /var/www/letsencrypt
   {{ end }}
 {{ end }}
 docker-gen -only-exposed -notify "nginx -s reload" /app/nginx.tmpl /etc/nginx/conf.d/default.conf
-


### PR DESCRIPTION
The log file in /var/log/letsencrypt was causing some problems with createSSL.sh was running. He file was on a layer of the overlay  filesystem that prevented it from being renamed. By removing it from the filesystem, things ran smoothly.